### PR TITLE
Prepare code for move to ECDC repository

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,6 @@
 on:
-  push
+  workflow_dispatch:
+  push:
 
 name: R-CMD-check
 
@@ -30,10 +31,16 @@ jobs:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
+      - name: Install libcurl on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: '"hard"'
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
 
       - uses: r-lib/actions/check-r-package@v2
         env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,6 @@ Imports:
     xml2 (>= 1.2.0)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 LinkingTo: Rcpp
 Suggests: testthat

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Status
 
-[![R-CMD-check](https://github.com/nextpagesoft/hivModelling/workflows/R-CMD-check/badge.svg)](https://github.com/nextpagesoft/hivModelling/actions)
+[![R-CMD-check](../../actions/workflows/R-CMD-check.yaml/badge.svg)](../../actions/workflows/R-CMD-check.yaml)
 
 # Amsterdam UMC
 
@@ -17,5 +17,5 @@ diagnosis;
 
 # License
 
-See the [LICENSE](https://github.com/nextpagesoft/hivModelling/blob/master/LICENSE) file for
+See the [LICENSE](LICENSE) file for
 license rights and limitations (EUPL-1.2).

--- a/utils/Update local dependencies.R
+++ b/utils/Update local dependencies.R
@@ -1,2 +1,4 @@
 # 1. Update local packages -------------------------------------------------------------------------
+dir.create('library', showWarnings = FALSE)
+.libPaths('./library')
 pak::local_install_deps(root = '.', dependencies = 'hard', upgrade = TRUE)


### PR DESCRIPTION
This PR adjust paths in README to be relative and hence support move of `hivModelling` R package to EU-ECDC GitHub account.